### PR TITLE
Adjust datatypes for trait_efos column to allow for array(null)

### DIFF
--- a/terraform_create_images/modules/loader_vm/scripts/clickhouse/sql/studies_log.sql
+++ b/terraform_create_images/modules/loader_vm/scripts/clickhouse/sql/studies_log.sql
@@ -9,7 +9,7 @@ create table if not exists ot.studies_log (
   has_sumstats UInt8,
   trait_reported String,
   source Nullable(String),
-  trait_efos Array(String) default [],
+  trait_efos Array(Nullable(String)) default [],
   ancestry_initial Array(String) default [],
   ancestry_replication Array(String) default [],
   n_initial Nullable(UInt32),


### PR DESCRIPTION
Change to go along with `sumstats_to_parquet.py` so that the trait_efos column can contain empty arrays. In the current version the empty arrays generated by [this commit](https://github.com/thehyve/otg-data-loading/commit/853b8fd2b5f82309df542c5733b50aeb6b6b5205) for `sumstats_to_parquet.py` creates an empty array which gets interpreted as null by clickhouse, which is a mismatch with `Array(String)`. 